### PR TITLE
Added API Guidelines Section for Clarity

### DIFF
--- a/project.org
+++ b/project.org
@@ -167,9 +167,8 @@
    When building your API, try to adhere to these rules for easy compatibility with other groups:
    
    - REST API calls may be prefixed. ie. http://service_address/api/author/{AUTHOR_ID}/posts/
-   - Document your service address, port, hostname, and prefix(if used) in your README so that HTTP clients can connect
-    to your API.
-   - Implement HTTP Basic Auth. Your server should send the "WWW-Authenticate" header in the response headers.
+   - Document your service address, port, hostname, prefix(if used), and the username/password for HTTP
+    Basic Auth(if used) in your README so that HTTP clients can connect to your API.
 
 ** Submission Instructions
    - Fork my repository from github

--- a/project.org
+++ b/project.org
@@ -164,10 +164,11 @@
 
 ** API Guidelines
    
-   When building your API, try to adhere to these rules for easy compatability with other groups:
+   When building your API, try to adhere to these rules for easy compatibility with other groups:
    
-   - REST API calls should be prefixed with /api/ ie. http://service_address/api/author/{AUTHOR_ID}/posts
-   - Document your service address, port, and hostname in your README so that HTTP clients can connect to your API.
+   - REST API calls may be prefixed. ie. http://service_address/api/author/{AUTHOR_ID}/posts/
+   - Document your service address, port, hostname, and prefix(if used) in your README so that HTTP clients can connect
+    to your API.
    - Implement HTTP Basic Auth. Your server should send the "WWW-Authenticate" header in the response headers.
 
 ** Submission Instructions

--- a/project.org
+++ b/project.org
@@ -162,6 +162,14 @@
    - [ ] License your code properly (use an OSI approved license)
      - Put your name on it!
 
+** API Guidelines
+   
+   When building your API, try to adhere to these rules for easy compatability with other groups:
+   
+   - REST API calls should be prefixed with /api/ ie. http://service_address/api/author/{AUTHOR_ID}/posts
+   - Document your service address, port, and hostname in your README so that HTTP clients can connect to your API.
+   - Implement HTTP Basic Auth. Your server should send the "WWW-Authenticate" header in the response headers.
+
 ** Submission Instructions
    - Fork my repository from github
       https://github.com/abramhindle/CMPUT404-project-socialdistribution


### PR DESCRIPTION
We briefly discussed this at the end of class for a pull request that specifies some guidelines for the HTTP Basic Auth.

I'm not entirely sure if I misinterpreted what was asked of me. Please correct me if I did.