### PR TITLE
Update example-article.json

### DIFF
--- a/example-article.json
+++ b/example-article.json
@@ -11,11 +11,29 @@ This file specifies what posts look like:
 # http://service/author/{AUTHOR_ID}/posts (all posts made by {AUTHOR_ID} visible to the currently authenticated user)
 # or
 # http://service/posts/{POST_ID} access to a single post with id = {POST_ID}
+# or
+# http://service/posts/{post_id}/comments access to the comments in a post
 #
 # All of the previous URIs will get a list of posts like this:
 
+# If a page is provided, return the results for that page, if no page is provided return page 0
+# If a size is provided, return pages in this size up to the maximum set on the server. If no size is provided
+# return the default page size
+# Use same pagination style for all endpoints in this file
+# Example:
+# GET http://service/author/posts?page=4&size=50
+# GET http://service/author/posts?page=4
 {
-    # A list of posts
+    "query": "posts",
+    # number of posts
+    "count": 1023,
+    # Page size
+    "size": 50,
+    # Do not return next if last page
+    "next": "http://service/author/posts?page=5",
+    # Do not return previous if page is 0.
+    "previous": "http://service/author/posts?page=3",
+    # should be sorted newest(first) to oldest(last) 
     "posts":[
         {
             # title of a post
@@ -33,7 +51,7 @@ This file specifies what posts look like:
             # text/plain
             # for HTML you will want to strip tags before displaying
             "content-type":"text/html",
-            "content":"Þā wæs on burgum Bēowulf Scyldinga, lēof lēod-cyning, longe þrāge folcum gefrǣge (fæder ellor hwearf, aldor of earde), oð þæt him eft onwōc hēah Healfdene; hēold þenden lifde, gamol and gūð-rēow, glæde Scyldingas. Þǣm fēower bearn forð-gerīmed in worold wōcun, weoroda rǣswan, Heorogār and Hrōðgār and Hālga til; hȳrde ic, þat Elan cwēn Ongenþēowes wæs Heaðoscilfinges heals-gebedde. Þā wæs Hrōðgāre here-spēd gyfen, wīges weorð-mynd, þæt him his wine-māgas georne hȳrdon, oð þæt sēo geogoð gewēox, mago-driht micel. Him on mōd bearn, þæt heal-reced hātan wolde, medo-ærn micel men gewyrcean, þone yldo bearn ǣfre gefrūnon, and þǣr on innan eall gedǣlan geongum and ealdum, swylc him god sealde, būton folc-scare and feorum gumena. Þā ic wīde gefrægn weorc gebannan manigre mǣgðe geond þisne middan-geard, folc-stede frætwan. Him on fyrste gelomp ǣdre mid yldum, þæt hit wearð eal gearo, heal-ærna mǣst; scōp him Heort naman, sē þe his wordes geweald wīde hæfde. Hē bēot ne ālēh, bēagas dǣlde, sinc æt symle. Sele hlīfade hēah and horn-gēap: heaðo-wylma bād, lāðan līges; ne wæs hit lenge þā gēn þæt se ecg-hete āðum-swerian 85 æfter wæl-nīðe wæcnan scolde. Þā se ellen-gǣst earfoðlīce þrāge geþolode, sē þe in þȳstrum bād, þæt hē dōgora gehwām drēam gehȳrde hlūdne in healle; þǣr wæs hearpan swēg, swutol sang scopes. Sægde sē þe cūðe frum-sceaft fīra feorran reccan",
+            "content":"Þā wæs on burgum Bēowulf Scyldinga, lēof lēod-cyning, longe þrāge folcum gefrǣge (fæder ellor hwearf, aldor of earde), oð þæt him eft onwōc hēah Healfdene; hēold þenden lifde, gamol and gūð-rēow, glæde Scyldingas. Þǣm fēower bearn forð-gerīmed in worold wōcun, weoroda rǣswan, Heorogār and Hrōðgār and Hālga til; hȳrde ic, þat Elan cwēn Ongenþēowes wæs Heaðoscilfinges heals-gebedde. Þā wæs Hrōðgāre here-spēd gyfen, wīges weorð-mynd, þæt him his wine-māgas georne hȳrdon, oð þæt sēo geogoð gewēox, mago-driht micel. Him on mōd bearn, þæt heal-reced hātan wolde, medo-ærn micel men gewyrcean, þone yldo bearn ǣfre gefrūnon, and þǣr on innan eall gedǣlan geongum and ealdum, swylc him god sealde, būton folc-scare and feorum gumena. Þā ic wīde gefrægn weorc gebannan manigre mǣgðe geond þisne middan-geard, folc-stede frætwan. Him on fyrste gelomp ǣdre mid yldum, þæt hit wearð eal gearo, heal-ærna mǣst; scōp him Heort naman, sē þe his wordes geweald wīde hæfde. Hē bēot ne ālēh, bēagas dǣlde, sinc æt symle. Sele hlīfade hēah and horn-gēap: heaðo-wylma bād, lāðan līges; ne wæs hit lenge þā gēn þæt se ecg-hete āðum-swerian 85 æfter wæl-nīðe wæcnan scolde. Þā se ellen-gǣst earfoðlīce þrāge geþolode, sē þe in þȳstrum bād, þæt hē dōgora gehwām drēam gehȳrde hlūdne in healle; þǣr wæs hearpan swēg, swutol sang scopes. Sægde sē þe cūðe frum-sceaft fīra feorran reccan",
             # the author has an ID where by authors can be disambiguated 
             "author":{
                 # unique id to each author, either a sha1 or a uuid
@@ -47,9 +65,19 @@ This file specifies what posts look like:
             },
             # categories this post fits into (a list of strings
             "categories":["web","tutorial"],
-            # comments about the post
-            "comments":[
-                {
+            # Return say 5 comments here. Server can fetch more for specific posts.
+            "post_comments":{
+        	# comments about the post
+            	# return a maximum number of comments
+            	# total number of comments for this post
+    	    	"count": 1023,
+    	    	# page size
+    	    	"size": 50,
+    	    	# the first page of comments
+            	"next": "http://service/posts/{post_id}/comments",
+    	    	# You should return ~ 5 comments per post.
+    	    	 # should be sorted newest(first) to oldest(last) 
+            	"comments":[{
                     "author":{
                         "id":"8d919f29c12e8f97bcbbd34cc908f19ab9496989",
                         "host":"http://127.0.0.1:5454/",
@@ -58,8 +86,8 @@ This file specifies what posts look like:
                     "comment":"Sick Olde English"
                     "pubDate":"Fri Jan  3 15:50:40 MST 2014",
                     "guid":"5471fe89-7697-4625-a06e-b3ad18577b72"
-                }
-            ]
+                }]
+            }
             # when published
             "pubDate":"Fri Jan  1 12:12:12 MST 2014",
             # ID of the post (uuid or sha1)
@@ -75,6 +103,35 @@ This file specifies what posts look like:
         }
     ]
 }
+
+
+# Example 
+# http://service/posts/{post_id}/comments access to the comments in a post
+# http://service/posts/{post_id}/comments?page=4
+# http://service/posts/{post_id}/comments?page=4&size=40
+{
+	"query": "comments",
+        # comments about the post
+        # return a maximum number of comments
+        # A list of posts
+    	"count": 1023,
+    	"size": 50,
+    	# Do not return next if last page
+        "next": "http://service/posts/{post_id}/comments?page=5",
+    	# Do not return previous if page is 0.
+    	"previous": "http://service/posts/{post_id}/comments?page=3",
+        "comments":[{
+        	"author":{
+                	"id":"8d919f29c12e8f97bcbbd34cc908f19ab9496989",
+                	"host":"http://127.0.0.1:5454/",
+                	"displayname":"Greg"
+        	},
+        	"comment":"Sick Olde English"
+       		"pubDate":"Fri Jan  3 15:50:40 MST 2014",
+                "guid":"5471fe89-7697-4625-a06e-b3ad18577b72"
+        }]
+}
+
 
 # a reponse if friends or not
 # ask a service http://service/friends/9de17f29c12e8f97bcbbd34cc908f1baba40658e/8d919f29c12e8f97bcbbd34cc908f19ab9496989


### PR DESCRIPTION
"post_comments", could be set to just return a URL instead, but I thought it might be useful to show last 5-10 comments for a summary. 
- Possibility to use last id if the comments/posts changes while paging not sure if it is necessary for this assignment.