### PR TITLE
Changing a Few Inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ Contributors:
     Olexiy Berjanskii
     Erin Torbiak
     Abram Hindle
+    Braedy Kuzma

--- a/example-article.json
+++ b/example-article.json
@@ -319,7 +319,7 @@ responds with:
   ],
 
   # Optional attributes
-  "github": "lara",
+  "github": "http://github.com/lara",
   "firstName": "Lara",
   "lastName": "Smith",
   "email": "lara@lara.com",

--- a/example-article.json
+++ b/example-article.json
@@ -39,9 +39,9 @@ This file specifies what posts look like:
 			# title of a post
 			"title":"A post title about a post about web dev",
 			# where did you get this post from?
-			"source":"http://lastplaceigotthisfrom.com/post/yyyyy",
+			"source":"http://lastplaceigotthisfrom.com/posts/yyyyy",
 			# where is it actually from
-			"origin":"http://whereitcamefrom.com/post/zzzzz",
+			"origin":"http://whereitcamefrom.com/posts/zzzzz",
 			# a brief description of the post
 			"description":"This post discusses stuff -- brief",
 			# The content type of the post

--- a/example-article.json
+++ b/example-article.json
@@ -33,7 +33,7 @@ This file specifies what posts look like:
 	"next": "http://service/author/posts?page=5",
 	# Do not return previous if page is 0.
 	"previous": "http://service/author/posts?page=3",
-	# should be sorted newest(first) to oldest(last) 
+	# should be sorted newest(first) to oldest(last)
 	"posts":[
 		{
 			# title of a post
@@ -54,9 +54,9 @@ This file specifies what posts look like:
 			# for HTML you will want to strip tags before displaying
 			"contentType":"text/plain",
 			"content":"Þā wæs on burgum Bēowulf Scyldinga, lēof lēod-cyning, longe þrāge folcum gefrǣge (fæder ellor hwearf, aldor of earde), oð þæt him eft onwōc hēah Healfdene; hēold þenden lifde, gamol and gūð-rēow, glæde Scyldingas. Þǣm fēower bearn forð-gerīmed in worold wōcun, weoroda rǣswan, Heorogār and Hrōðgār and Hālga til; hȳrde ic, þat Elan cwēn Ongenþēowes wæs Heaðoscilfinges heals-gebedde. Þā wæs Hrōðgāre here-spēd gyfen, wīges weorð-mynd, þæt him his wine-māgas georne hȳrdon, oð þæt sēo geogoð gewēox, mago-driht micel. Him on mōd bearn, þæt heal-reced hātan wolde, medo-ærn micel men gewyrcean, þone yldo bearn ǣfre gefrūnon, and þǣr on innan eall gedǣlan geongum and ealdum, swylc him god sealde, būton folc-scare and feorum gumena. Þā ic wīde gefrægn weorc gebannan manigre mǣgðe geond þisne middan-geard, folc-stede frætwan. Him on fyrste gelomp ǣdre mid yldum, þæt hit wearð eal gearo, heal-ærna mǣst; scōp him Heort naman, sē þe his wordes geweald wīde hæfde. Hē bēot ne ālēh, bēagas dǣlde, sinc æt symle. Sele hlīfade hēah and horn-gēap: heaðo-wylma bād, lāðan līges; ne wæs hit lenge þā gēn þæt se ecg-hete āðum-swerian 85 æfter wæl-nīðe wæcnan scolde. Þā se ellen-gǣst earfoðlīce þrāge geþolode, sē þe in þȳstrum bād, þæt hē dōgora gehwām drēam gehȳrde hlūdne in healle; þǣr wæs hearpan swēg, swutol sang scopes. Sægde sē þe cūðe frum-sceaft fīra feorran reccan",
-			# the author has an ID where by authors can be disambiguated 
+			# the author has an ID where by authors can be disambiguated
 			"author":{
-				# ID of the Author 
+				# ID of the Author
 				"id":"http://127.0.0.1:5454/author/9de17f29c12e8f97bcbbd34cc908f1baba40658e",
 				# the home host of the author
 				"host":"http://127.0.0.1:5454/",
@@ -78,7 +78,7 @@ This file specifies what posts look like:
 			# the first page of comments
 			"next": "http://service/posts/{post_id}/comments",
 			# You should return ~ 5 comments per post.
-			# should be sorted newest(first) to oldest(last) 
+			# should be sorted newest(first) to oldest(last)
 			"comments":[
 				{
 					"author":{
@@ -111,7 +111,7 @@ This file specifies what posts look like:
 			# If any of my friends are your friends I can see the post
 			# FRIENDS means if we're direct friends I can see the post
 			# PRIVATE means only you can see the post
-			# SERVERONLY means only those on your server (your home server) can see the post                                              
+			# SERVERONLY means only those on your server (your home server) can see the post
 			# PRIVATE means only authors listed in "visibleTo" can see the post
                         "unlisted":false
                         # unlisted means it is public if you know the post name -- use this for images, it's so images don't show up in timelines
@@ -120,7 +120,7 @@ This file specifies what posts look like:
 }
 
 
-# Example 
+# Example
 # http://service/posts/{post_id}/comments access to the comments in a post
 # http://service/posts/{post_id}/comments?page=4
 # http://service/posts/{post_id}/comments?page=4&size=40
@@ -171,7 +171,7 @@ This file specifies what posts look like:
 	   "guid":"de305d54-75b4-431b-adb2-eb6b9e546013"
 	}
 }
-# Responds with 
+# Responds with
 # 200 OK
 {
 	"query": "addComment",
@@ -205,7 +205,7 @@ responds with:
 # STRIP the http:// and https:// from the URI in the restful query
 # If you need a template (optional): GET http://service/author/<authorid1>/friends/<service2>/author/<authorid2>
 # where authorid1 = de305d54-75b4-431b-adb2-eb6b9e546013 (actually author http://service/author/de305d54-75b4-431b-adb2-eb6b9e546013 )
-# where authorid2 = 
+# where authorid2 =
 # GET http://service/author/de305d54-75b4-431b-adb2-eb6b9e546013/friends/127.0.0.1%3A5454/author/ae345d54-75b4-431b-adb2-fb6b9e547891
 # responds with:
 {	"query":"friends",


### PR DESCRIPTION
The `post` -> `posts` change was  discussed in class and said to be a typo.
The `github` field inconsistency I was unsure of and am willing to make the change in the opposite direction if the field should have the github username and not their profile URL.