### PR TITLE
Proposal for notifying users of their friend request status

### DIFF
--- a/example-article.json
+++ b/example-article.json
@@ -301,6 +301,25 @@ responds with:
 
 # to unfriend simply do it locally
 
+# to notify the requestor about the acceptance or rejection of their friend requests make to http://service/notify
+# accepted: true if accepted, false if rejected
+{
+	"event": "friendrequest",
+	"accepted": true,
+	"from": {
+		"id":"http://remoteserver:5454/author/de305d54-75b4-431b-adb2-eb6b9e546013",
+		"host":"http://remoteserver:5454/",
+		"displayName":"Greg Johnson",
+		"url":"http://remoteserver:5454/author/de305d54-75b4-431b-adb2-eb6b9e546013"
+	},
+	"to": {
+		"id":"http://localserver:5454/author/526ec14b-9eb8-4923-982e-26ee9748d8053",
+		"host":"http://localserver:5454/",
+		"displayName":"John Gregson",
+		"url":"http://localserver:5454/author/526ec14b-9eb8-4923-982e-26ee9748d805",
+	}
+}
+
 # Profile API calls
 # GET http://service/author/9de17f29c12e8f97bcbbd34cc908f1baba40658e
 # Enables viewing of foreign author's profiles

--- a/project.org
+++ b/project.org
@@ -146,6 +146,7 @@
    - [ ] Allow users to accept or reject friend requests
    - [ ] friend requests can be made by POSTing a friend request to 
      http://service/friendrequest
+   - [ ] Friend request acceptions or rejection notifications are delivered to the origin server via a POST to http://service/notify
    - [ ] http://service/author/posts (posts that are visible to the currently authenticated user)
    - [ ] http://service/author/{AUTHOR_ID}/posts (all posts made by {AUTHOR_ID} visible to the currently authenticated user)
    - [ ] Images get the same protection that posts get as they are POSTS   


### PR DESCRIPTION
@abramhindle I'm proposing adding two things 

1. A generic notification endpoint (a la web hooks)
2. Notification type for the result of sending a friend request.

Currently it is possible to determine if a user's friend request was accepted (because the remote server will hit the origin server's `/friendrequest` endpoint, but there is no notification for if the friend request was explicitly rejected. Moreover, we cannot know if the remote server unfriended the local user. 

I propose that this functionality be implemented via a generic `/notify` endpoint that can be further extended for other notification type messages. 

If the server does not understand the `event` type then it can be ignored.