### PR TITLE
changed follow request type from Follow to follow for consistency

### DIFF
--- a/project.org
+++ b/project.org
@@ -310,7 +310,7 @@
     - Example format:
       #+BEGIN_SRC json
       {
-          "type": "follow",      
+          "type": "Follow",      
           "summary":"Greg wants to follow Lara",
           "actor":{
               "type":"author",
@@ -583,8 +583,8 @@
       - GET [local]: if authenticated get a list of posts sent to AUTHOR_ID (paginated)
       - POST [local, remote]: send a post to the author
         - if the type is "post" then add that post to AUTHOR_ID's inbox
-        - if the type is "follow" then add that follow is added to AUTHOR_ID's inbox to approve later
-        - if the type is "like" then add that like to AUTHOR_ID's inbox
+        - if the type is "Follow" then add that follow is added to AUTHOR_ID's inbox to approve later
+        - if the type is "Like" then add that like to AUTHOR_ID's inbox
         - if the type is "comment" then add that comment to AUTHOR_ID's inbox
       - DELETE [local]: clear the inbox
     - Example, retrieving an inbox

--- a/project.org
+++ b/project.org
@@ -310,7 +310,7 @@
     - Example format:
       #+BEGIN_SRC json
       {
-          "type": "Follow",      
+          "type": "follow",      
           "summary":"Greg wants to follow Lara",
           "actor":{
               "type":"author",


### PR DESCRIPTION
The spec specifies the follow object to have "type":"Follow" but then under inbox it says: 
"if the type is “follow” then add that follow is added to AUTHOR_ID’s inbox to approve later"

This caused some confusing between groups so I think it's best if the follow object has "type":"follow"